### PR TITLE
feat(api): included compilation time in responses

### DIFF
--- a/src/constants.cr
+++ b/src/constants.cr
@@ -7,8 +7,13 @@ module PlaceOS::Build
   BUILD_TIME   = {{ system("date -u").chomp.stringify }}
   BUILD_COMMIT = {{ env("PLACE_COMMIT") || "DEV" }}
 
-  CRYSTAL_VERSION   = {{ env("CRYSTAL_VERSION") || "latest" }}
-  DRIVER_HEADER_KEY = "X-PLACEOS-DRIVER-KEY"
+  CRYSTAL_VERSION = {{ env("CRYSTAL_VERSION") || "latest" }}
+
+  # Keys in API responses
+  #############################################################################
+
+  DRIVER_HEADER_KEY  = "X-PLACEOS-DRIVER-KEY"
+  DRIVER_HEADER_TIME = "X-PLACEOS-DRIVER-TIME"
 
   # S3 caching
   #############################################################################

--- a/src/placeos-build/api/driver.cr
+++ b/src/placeos-build/api/driver.cr
@@ -56,7 +56,7 @@ module PlaceOS::Build::Api
         head code: :not_found
       in Drivers::Compilation::Success
         response.content_type = "application/octet-stream"
-        response.headers[DRIVER_HEADER_KEY] = Path[result.path].basename
+        response.headers.merge(result.to_http_headers)
         response.content_length = File.size(result.path)
         File.open(result.path) do |file_io|
           IO.copy(file_io, response)

--- a/src/placeos-build/client.cr
+++ b/src/placeos-build/client.cr
@@ -137,13 +137,12 @@ module PlaceOS::Build
         "url"    => url,
         "commit" => commit,
       }
-      driver_key = post("/driver/#{URI.encode_www_form(file)}?#{params}", authorization_header(username, password), request_id: request_id, raises: false, retries: 2) do |response|
+      post("/driver/#{URI.encode_www_form(file)}?#{params}", authorization_header(username, password), request_id: request_id, raises: false, retries: 2) do |response|
         key = response.headers[DRIVER_HEADER_KEY]
+        time = response.headers[DRIVER_HEADER_TIME]
         yield key, response.body_io
-        key
+        Compilation::Success.new(key, time)
       end
-
-      Compilation::Success.new(driver_key)
     rescue e : Build::ClientError
       case e.response.status_code
       when 404 then Compilation::NotFound.new

--- a/src/placeos-build/compilation.cr
+++ b/src/placeos-build/compilation.cr
@@ -3,7 +3,27 @@ module PlaceOS::Build
     alias Result = Success | Failure | NotFound
 
     record NotFound
-    record Success, path : String
+
+    struct Success
+      include JSON::Serializable
+
+      getter path : String
+
+      @[JSON::Field(converter: Time::EpochMillisConverter)]
+      getter compiled : Time
+
+      def initialize(@path, compiled = Time.utc)
+        @compiled = compiled.is_a?(Time) ? compiled : Time.unix_ms(compiled)
+      end
+
+      def to_http_headers
+        {
+          DRIVER_HEADER_KEY  => Path[path].basename,
+          DRIVER_HEADER_TIME => compiled.total_milliseconds,
+        }
+      end
+    end
+
     record Failure, error : String do
       include JSON::Serializable
     end


### PR DESCRIPTION
Adds a `compiled` key to the compilation result, indicating when the driver was last compiled.

This is not necessarily going to be correct for items pulled from the s3 store. 

We could encode build time into the key but i think this'll do for now, just to get the interface up and running.