### PR TITLE
chore: placeos-models ~>5.9

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -42,7 +42,7 @@ dependencies:
     github: place-labs/log-backend
   placeos-models:
     github: placeos/models
-    version: ~> 5.6
+    version: ~> 5.9
   raven:
     github: Sija/raven.cr
     branch: master


### PR DESCRIPTION
Updates minimum supported `placeos-models` version.

`v5.10.0` was already the locked version here, but bumping min spec for safety.