### PR TITLE
fix: prevent handler wedge from stalled clients and spawn failures

### DIFF
--- a/src/placeos-build/api/driver.cr
+++ b/src/placeos-build/api/driver.cr
@@ -93,6 +93,7 @@ module PlaceOS::Build::Api
               Log.warn { "aborting stalled response stream after #{stream_timeout.total_seconds}s" }
               response.output.close rescue nil
             end
+            done.close
           end
 
           begin

--- a/src/placeos-build/api/driver.cr
+++ b/src/placeos-build/api/driver.cr
@@ -75,8 +75,31 @@ module PlaceOS::Build::Api
         response.status_code = 200
         @__render_called__ = true
 
+        # A firewall-blocked or stalled client can leave the response socket
+        # unwritable indefinitely; without a write timeout `IO.copy` parks the
+        # fiber and the open file + socket descriptors are held until the
+        # kernel's TCP retransmits give up. A watchdog fiber closes the output
+        # if the copy hasn't completed in time, which unblocks `IO.copy` and
+        # releases the descriptors.
         File.open(path) do |file_io|
-          IO.copy(file_io, response)
+          stream_timeout = 60.seconds
+          done = Channel(Nil).new(1)
+
+          spawn(same_thread: true) do
+            select
+            when done.receive
+              # copy finished (success or error) — nothing to do
+            when timeout(stream_timeout)
+              Log.warn { "aborting stalled response stream after #{stream_timeout.total_seconds}s" }
+              response.output.close rescue nil
+            end
+          end
+
+          begin
+            IO.copy(file_io, response)
+          ensure
+            done.send(nil) rescue nil
+          end
         end
       in Build::Compilation::Failure
         raise AC::Error::Failure.new(result.error)

--- a/src/placeos-build/cli/cloud_builder.cr
+++ b/src/placeos-build/cli/cloud_builder.cr
@@ -23,6 +23,12 @@ module PlaceOS::Build
     }
 
     client = HTTP::Client.new(URI.parse(BUILD_SERVICE_URL))
+    # This POST is synchronous inside `trigger_build`, and it reaches us back
+    # through `build.placeos.run` — so anything that slows that round-trip (LB,
+    # the sibling arch instance, outbound network) would otherwise pin every
+    # handler indefinitely. Bound it.
+    client.connect_timeout = 10.seconds
+    client.read_timeout = 30.seconds
     begin
       ["amd64", "arm64"].each do |arch|
         Log.debug { "Sending #{entrypoint} compilation request for architecture #{arch}" }

--- a/src/placeos-build/run_from.cr
+++ b/src/placeos-build/run_from.cr
@@ -7,30 +7,45 @@ module RunFrom
 
   def self.run_from(path, command, args, timeout : Time::Span = 10.minutes, **rest)
     # Run in a different thread to prevent blocking
-    channel = Channel(Process::Status).new(capacity: 1)
+    channel = Channel(Process::Status | Exception).new(capacity: 1)
     output = IO::Memory.new
     process = nil
 
     fiber = spawn(same_thread: true) do
-      process = Process.new(
-        command,
-        **rest,
-        args: args,
-        input: Process::Redirect::Close,
-        output: output,
-        error: output,
-        chdir: path,
-      )
+      begin
+        process = Process.new(
+          command,
+          **rest,
+          args: args,
+          input: Process::Redirect::Close,
+          output: output,
+          error: output,
+          chdir: path,
+        )
 
-      status = process.as(Process).wait
-      channel.send(status) unless channel.closed?
+        status = process.as(Process).wait
+        channel.send(status) unless channel.closed?
+      rescue e
+        # Surface spawn failures (EMFILE on pipe(), missing binary, chdir errors,
+        # etc.) immediately instead of letting the caller wait the full `timeout`.
+        channel.send(e) rescue nil
+      end
     end
 
     Fiber.yield
     fiber.resume if fiber.running?
 
     select
-    when status = channel.receive
+    when result = channel.receive
+      case result
+      in Process::Status
+        Result.new(result, output)
+      in Exception
+        raise PlaceOS::Build::Error.new(
+          "Failed to launch #{command}: #{result.class}: #{result.message}\n#{output}",
+          cause: result,
+        )
+      end
     when timeout(timeout)
       channel.close
       begin
@@ -41,7 +56,5 @@ module RunFrom
 
       raise PlaceOS::Build::Error.new("Running #{command} timed out after #{timeout.total_seconds}s with:\n#{output}")
     end
-
-    Result.new(status, output)
   end
 end

--- a/src/placeos-build/run_from.cr
+++ b/src/placeos-build/run_from.cr
@@ -11,7 +11,7 @@ module RunFrom
     output = IO::Memory.new
     process = nil
 
-    fiber = spawn(same_thread: true) do
+    spawn(same_thread: true) do
       begin
         process = Process.new(
           command,
@@ -32,11 +32,10 @@ module RunFrom
       end
     end
 
-    Fiber.yield
-    fiber.resume if fiber.running?
-
     select
     when result = channel.receive
+      channel.close
+
       case result
       in Process::Status
         Result.new(result, output)


### PR DESCRIPTION
- api/driver.cr: watchdog fiber aborts the response stream after 60s so a firewall-blocked or half-open client can't park IO.copy indefinitely and hold open the response socket + binary file descriptors.
- cli/cloud_builder.cr: bound the synchronous cloud-builder POST with connect (10s) and read (30s) timeouts so a slow gateway or sibling arch instance can't pin every cached-response handler.
- run_from.cr: rescue exceptions inside the spawned fiber and propagate them through the channel as a Build::Error, so subprocess spawn failures (EMFILE, missing binary, bad chdir) surface immediately instead of waiting the full 10-minute select timeout.

Together these stop a client-side firewall flood from cascading into FD exhaustion that silently kills every subsequent Process.new for the next ten minutes per request, which was the suspected cause of the build server going dormant until container restart.

